### PR TITLE
Quit driver in destructor of RUC_LOGIN

### DIFF
--- a/ruclogin/ruclogin.py
+++ b/ruclogin/ruclogin.py
@@ -327,6 +327,11 @@ class RUC_LOGIN:
                 return
         raise TimeoutError("Login failed, try too many times")
 
+    def __del__(self):
+        if hasattr(self, 'driver'):
+            self.driver.quit()
+        return
+
 
 def driver_init(debug=False):
     global loginer_instance


### PR DESCRIPTION
目前运行完没关ChromeDriver，自动化运行的时候内存会炸

![image](https://github.com/user-attachments/assets/46389ed7-a908-4b79-b3a4-6b6c39bb2190)